### PR TITLE
Added device TC4DAx

### DIFF
--- a/gcc/config/tricore/devices.def
+++ b/gcc/config/tricore/devices.def
@@ -78,3 +78,4 @@ DEF_DEVICE ("tc2d5d", "0x2d5d", "161", "tc161")
 DEF_DEVICE ("tc38xx", "0x3800", "162", "tc162") /* since v4.9.1.0-infineon-2.0 */
 DEF_DEVICE ("tc39xx", "0x3900", "162", "tc162") /* since v4.6.6.0 */
 DEF_DEVICE ("tc49Ax", "0x4900", "18", "tc18")   /* updated */
+DEF_DEVICE ("tc4DAx", "0x4D00", "18", "tc18")   /* updated */

--- a/gcc/config/tricore/t-multilib
+++ b/gcc/config/tricore/t-multilib
@@ -57,6 +57,7 @@ MULTILIB_MATCHES = \
 	mtc161=mcpu?tc2d5d \
 	mtc162=mcpu?tc38xx \
 	mtc162=mcpu?tc39xx \
-	mtc18=mcpu?tc49Ax 
+	mtc18=mcpu?tc49Ax \
+	mtc18=mcpu?tc4DAx
 
-TRIC_DEVICES = tc1796 tc1130 tc116x tc1161 tc1162 tc1762 tc1764 tc1766 tc1792 tc1920 tc1167 tc1197 tc1337 tc1367 tc1387 tc1724 tc1728 tc1736 tc1767 tc1782 tc1783 tc1784 tc1797 tc1791 tc1793 tc1798 tc22xx tc23xx tc26xx tc27xx tc29xx tc2d5d tc38xx tc39xx tc49Ax
+TRIC_DEVICES = tc1796 tc1130 tc116x tc1161 tc1162 tc1762 tc1764 tc1766 tc1792 tc1920 tc1167 tc1197 tc1337 tc1367 tc1387 tc1724 tc1728 tc1736 tc1767 tc1782 tc1783 tc1784 tc1797 tc1791 tc1793 tc1798 tc22xx tc23xx tc26xx tc27xx tc29xx tc2d5d tc38xx tc39xx tc49Ax tc4DAx

--- a/gcc/config/tricore/tricore-mcpu.opt
+++ b/gcc/config/tricore/tricore-mcpu.opt
@@ -140,6 +140,9 @@ EnumValue
 Enum(tric_mcpu) String(tc49Ax) Value(34)
 
 EnumValue
+Enum(tric_mcpu) String(tc4DAx) Value(35)
+
+EnumValue
 Enum(tric_merrata) String(cpu048) Value(tric_errata_cpu048)
 
 EnumValue


### PR DESCRIPTION
Ciao Giuseppe, qui ho aggiunto un nuovo device (che ci servirà abbastanza tra qualche mese).
Ho operato sulla falsariga di quello fatto per TC49A, cercando di capire se effettivamente il valore 34 nell'enum tric_mcpu venga utilizzato da qualche parte. Mi è sembrato di no.