### PR TITLE
Add Tricore TC33x family CPU configuration

### DIFF
--- a/gcc/config/tricore/devices.def
+++ b/gcc/config/tricore/devices.def
@@ -75,6 +75,7 @@ DEF_DEVICE ("tc27xx", "0x2700", "161", "tc161")
 DEF_DEVICE ("tc29xx", "0x2900", "161", "tc161")
 DEF_DEVICE ("tc2d5d", "0x2d5d", "161", "tc161")
 
+DEF_DEVICE ("tc33xx", "0x3300", "162", "tc162")
 DEF_DEVICE ("tc38xx", "0x3800", "162", "tc162") /* since v4.9.1.0-infineon-2.0 */
 DEF_DEVICE ("tc39xx", "0x3900", "162", "tc162") /* since v4.6.6.0 */
 DEF_DEVICE ("tc49Ax", "0x4900", "18", "tc18")   /* updated */

--- a/gcc/config/tricore/memory.x
+++ b/gcc/config/tricore/memory.x
@@ -998,6 +998,34 @@ __ISTACK_SIZE = 256;
 __HEAP_MIN = 8K;
 __CSA_SIZE = 16K;
 
+#elif __TRICORE_NAME__  == 0x3300
+#define __MESSAGE__ "Using wrong Memory Map. This Map is for TC33xx"
+#define I_C_F_B	  0x80000000
+#define I_C_F_S	  2M
+#define I_C_F_B_0 0x80000000
+#define I_C_F_S_0 2M
+#define I_D_F_B   0xaf000000
+#define I_D_F_S	   128K
+#define I_D_F_B_0 0xaf000000
+#define I_D_F_S_0  128K
+#define E_C_R_B	  0
+#define E_C_R_S	  0
+#define E_D_R_B	  0
+#define E_D_R_S	  0
+#define I_C_R_B	  0xc0000000
+#define I_C_R_S	   8K
+#define I_D_R_B	  0xd0000000
+#define I_D_R_S	   192K
+#define P_C_R_B	  0
+#define P_C_R_S	  0
+#define P_D_R_B	  0
+#define P_D_R_S	  0
+
+__USTACK_SIZE = 4K;
+__ISTACK_SIZE = 256;
+__HEAP_MIN = 8K;
+__CSA_SIZE = 16K;
+
 #elif __TRICORE_NAME__  == 0x3900
 #define __MESSAGE__ "Using wrong Memory Map. This Map is for TC39xx"
 #define I_C_F_B	  0x80000000

--- a/gcc/config/tricore/t-multilib
+++ b/gcc/config/tricore/t-multilib
@@ -55,9 +55,10 @@ MULTILIB_MATCHES = \
 	mtc161=mcpu?tc27xx \
 	mtc161=mcpu?tc29xx \
 	mtc161=mcpu?tc2d5d \
+	mtc162=mcpu?tc33xx \
 	mtc162=mcpu?tc38xx \
 	mtc162=mcpu?tc39xx \
 	mtc18=mcpu?tc49Ax \
 	mtc18=mcpu?tc4DAx 
 
-TRIC_DEVICES = tc1796 tc1130 tc116x tc1161 tc1162 tc1762 tc1764 tc1766 tc1792 tc1920 tc1167 tc1197 tc1337 tc1367 tc1387 tc1724 tc1728 tc1736 tc1767 tc1782 tc1783 tc1784 tc1797 tc1791 tc1793 tc1798 tc22xx tc23xx tc26xx tc27xx tc29xx tc2d5d tc38xx tc39xx tc49Ax tc4DAx
+TRIC_DEVICES = tc1796 tc1130 tc116x tc1161 tc1162 tc1762 tc1764 tc1766 tc1792 tc1920 tc1167 tc1197 tc1337 tc1367 tc1387 tc1724 tc1728 tc1736 tc1767 tc1782 tc1783 tc1784 tc1797 tc1791 tc1793 tc1798 tc22xx tc23xx tc26xx tc27xx tc29xx tc2d5d tc33xx tc38xx tc39xx tc49Ax tc4DAx

--- a/gcc/config/tricore/tricore-mcpu.opt
+++ b/gcc/config/tricore/tricore-mcpu.opt
@@ -131,16 +131,19 @@ EnumValue
 Enum(tric_mcpu) String(tc2d5d) Value(31)
 
 EnumValue
-Enum(tric_mcpu) String(tc38xx) Value(32)
+Enum(tric_mcpu) String(tc33xx) Value(32)
 
 EnumValue
-Enum(tric_mcpu) String(tc39xx) Value(33)
+Enum(tric_mcpu) String(tc38xx) Value(33)
 
 EnumValue
-Enum(tric_mcpu) String(tc49Ax) Value(34)
+Enum(tric_mcpu) String(tc39xx) Value(34)
 
 EnumValue
-Enum(tric_mcpu) String(tc4DAx) Value(35)
+Enum(tric_mcpu) String(tc49Ax) Value(35)
+
+EnumValue
+Enum(tric_mcpu) String(tc4DAx) Value(36)
 
 EnumValue
 Enum(tric_merrata) String(cpu048) Value(tric_errata_cpu048)


### PR DESCRIPTION
An attempt to add machine details for the TC33X family of tricore CPUs. I'm not yet familiar with this part of GCC source code (especially Machine Description files and how they are used to generate source code), hopefully I did it correctly.